### PR TITLE
Add multi-monitor support with per-display gamma settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,31 @@ sudo apt install python3-tk
 sudo apt install x11-xserver-utils
 ```
 
+## Multi-Monitor Support
+
+The app automatically detects all connected displays via `xrandr`. When multiple monitors are found:
+
+- A **Target** dropdown appears in the UI to select which monitor to adjust
+- Each monitor maintains its own independent gamma settings
+- Select **"All Monitors"** to adjust all displays at once
+- Settings are saved per-monitor in `~/.config/bluelight/settings.json`
+- On startup, saved settings are auto-applied to each monitor individually
+
+### Config Format
+
+Per-monitor settings are stored as:
+
+```json
+{
+  "monitors": {
+    "HDMI-1": {"r": 1.0, "g": 0.85, "b": 0.65},
+    "eDP-1": {"r": 1.0, "g": 0.75, "b": 0.50}
+  }
+}
+```
+
+Legacy single-monitor configs (`{"r", "g", "b"}`) are still supported and will be migrated on the next save.
+
 ## Project Structure
 
 ```
@@ -54,8 +79,8 @@ Each feature folder contains its code and colocated tests.
 | Folder | Purpose |
 |--------|---------|
 | `color/` | RGB gamma to hex conversion, warmth labels |
-| `config/` | Persistent settings in `~/.config/bluelight/settings.json` |
-| `display/` | xrandr wrapper — detect displays, apply gamma, build commands |
+| `config/` | Persistent per-monitor settings in `~/.config/bluelight/settings.json` |
+| `display/` | xrandr wrapper — detect all displays, apply gamma, build commands |
 | `theme/` | Color palette, font definitions, preset configurations |
 | `gui/` | Tkinter App class and custom Slider widget |
 

--- a/bluelight/config/__init__.py
+++ b/bluelight/config/__init__.py
@@ -11,6 +11,9 @@ CONFIG_FILE = CONFIG_DIR / "settings.json"
 def load_config(path=None):
     """Load saved gamma settings from config file.
 
+    Supports both legacy format {'r','g','b'} and multi-monitor
+    format {'monitors': {'OUTPUT': {'r','g','b'}, ...}}.
+
     Returns:
         dict: {'r': float, 'g': float, 'b': float} or empty dict if not found.
     """
@@ -19,6 +22,10 @@ def load_config(path=None):
         try:
             with open(cfg, 'r') as f:
                 data = json.load(f)
+                # Multi-monitor format
+                if 'monitors' in data:
+                    return data
+                # Legacy single-monitor format — return as-is for compat
                 return {
                     'r': float(data.get('r', 1.0)),
                     'g': float(data.get('g', 1.0)),
@@ -29,8 +36,39 @@ def load_config(path=None):
     return {}
 
 
-def save_config(r, g, b, path=None):
+def load_monitor_config(output=None, path=None):
+    """Load gamma settings for a specific monitor.
+
+    Args:
+        output: Monitor output name (e.g., "HDMI-1"). If None, returns defaults.
+        path: Optional config file path override.
+
+    Returns:
+        dict: {'r': float, 'g': float, 'b': float} or empty dict.
+    """
+    data = load_config(path)
+    if 'monitors' in data and output:
+        mon = data['monitors'].get(output, {})
+        if mon:
+            return {
+                'r': float(mon.get('r', 1.0)),
+                'g': float(mon.get('g', 1.0)),
+                'b': float(mon.get('b', 1.0))
+            }
+        return {}
+    # Legacy format or no output specified
+    if 'r' in data:
+        return data
+    return {}
+
+
+def save_config(r, g, b, path=None, output=None):
     """Save gamma settings to config file.
+
+    Args:
+        r, g, b: Gamma values.
+        path: Optional config file path override.
+        output: Monitor output name. If provided, saves per-monitor.
 
     Returns:
         bool: True if saved successfully.
@@ -38,8 +76,28 @@ def save_config(r, g, b, path=None):
     cfg = Path(path) if path else CONFIG_FILE
     try:
         cfg.parent.mkdir(parents=True, exist_ok=True)
-        with open(cfg, 'w') as f:
-            json.dump({'r': round(r, 2), 'g': round(g, 2), 'b': round(b, 2)}, f)
+        values = {'r': round(r, 2), 'g': round(g, 2), 'b': round(b, 2)}
+
+        if output:
+            # Load existing multi-monitor config
+            existing = {}
+            if cfg.exists():
+                try:
+                    with open(cfg, 'r') as f:
+                        existing = json.load(f)
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+            if 'monitors' not in existing:
+                # Migrate legacy format
+                existing = {'monitors': {}}
+            existing['monitors'][output] = values
+
+            with open(cfg, 'w') as f:
+                json.dump(existing, f)
+        else:
+            with open(cfg, 'w') as f:
+                json.dump(values, f)
         return True
     except Exception:
         return False

--- a/bluelight/config/tests.py
+++ b/bluelight/config/tests.py
@@ -4,7 +4,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
-from bluelight.config import load_config, save_config
+from bluelight.config import load_config, load_monitor_config, save_config
 
 
 class TestSaveConfig(unittest.TestCase):
@@ -76,6 +76,101 @@ class TestLoadConfig(unittest.TestCase):
             save_config(1.0, 0.75, 0.50, path=path)
             result = load_config(path=path)
             self.assertEqual(result, {'r': 1.0, 'g': 0.75, 'b': 0.5})
+
+
+class TestMultiMonitorConfig(unittest.TestCase):
+
+    def test_save_per_monitor(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            with open(path) as f:
+                data = json.load(f)
+            self.assertIn('monitors', data)
+            self.assertEqual(data['monitors']['HDMI-1'], {'r': 1.0, 'g': 0.85, 'b': 0.65})
+
+    def test_save_multiple_monitors(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            save_config(1.0, 0.75, 0.50, path=path, output="eDP-1")
+            with open(path) as f:
+                data = json.load(f)
+            self.assertEqual(data['monitors']['HDMI-1'], {'r': 1.0, 'g': 0.85, 'b': 0.65})
+            self.assertEqual(data['monitors']['eDP-1'], {'r': 1.0, 'g': 0.75, 'b': 0.5})
+
+    def test_save_overwrites_existing_monitor(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            save_config(1.0, 0.60, 0.35, path=path, output="HDMI-1")
+            result = load_monitor_config("HDMI-1", path=path)
+            self.assertEqual(result, {'r': 1.0, 'g': 0.6, 'b': 0.35})
+
+    def test_save_preserves_other_monitors(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            save_config(1.0, 0.75, 0.50, path=path, output="eDP-1")
+            save_config(1.0, 0.60, 0.35, path=path, output="HDMI-1")
+            result_hdmi = load_monitor_config("HDMI-1", path=path)
+            result_edp = load_monitor_config("eDP-1", path=path)
+            self.assertEqual(result_hdmi, {'r': 1.0, 'g': 0.6, 'b': 0.35})
+            self.assertEqual(result_edp, {'r': 1.0, 'g': 0.75, 'b': 0.5})
+
+    def test_load_monitor_config(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            result = load_monitor_config("HDMI-1", path=path)
+            self.assertEqual(result, {'r': 1.0, 'g': 0.85, 'b': 0.65})
+
+    def test_load_monitor_config_missing_monitor(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            result = load_monitor_config("eDP-1", path=path)
+            self.assertEqual(result, {})
+
+    def test_load_monitor_config_missing_file(self):
+        result = load_monitor_config("HDMI-1", path="/nonexistent/settings.json")
+        self.assertEqual(result, {})
+
+    def test_load_monitor_config_no_output(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            result = load_monitor_config(None, path=path)
+            self.assertEqual(result, {})
+
+    def test_load_monitor_config_legacy_format(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            with open(path, 'w') as f:
+                json.dump({'r': 1.0, 'g': 0.85, 'b': 0.65}, f)
+            result = load_monitor_config("HDMI-1", path=path)
+            self.assertEqual(result, {'r': 1.0, 'g': 0.85, 'b': 0.65})
+
+    def test_load_config_multi_monitor_format(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            result = load_config(path=path)
+            self.assertIn('monitors', result)
+            self.assertIn('HDMI-1', result['monitors'])
+
+    def test_roundtrip_multi_monitor(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "settings.json"
+            save_config(1.0, 0.85, 0.65, path=path, output="HDMI-1")
+            save_config(1.0, 0.75, 0.50, path=path, output="eDP-1")
+            save_config(1.0, 0.60, 0.35, path=path, output="DP-1")
+            self.assertEqual(load_monitor_config("HDMI-1", path=path),
+                             {'r': 1.0, 'g': 0.85, 'b': 0.65})
+            self.assertEqual(load_monitor_config("eDP-1", path=path),
+                             {'r': 1.0, 'g': 0.75, 'b': 0.5})
+            self.assertEqual(load_monitor_config("DP-1", path=path),
+                             {'r': 1.0, 'g': 0.6, 'b': 0.35})
 
 
 if __name__ == "__main__":

--- a/bluelight/display/__init__.py
+++ b/bluelight/display/__init__.py
@@ -5,19 +5,30 @@ import shutil
 
 
 def get_connected_output():
-    """Detect the connected display output name.
+    """Detect the first connected display output name.
 
     Returns:
         str or None: Output name (e.g., "HDMI-1") or None if not found.
     """
+    outputs = get_connected_outputs()
+    return outputs[0] if outputs else None
+
+
+def get_connected_outputs():
+    """Detect all connected display output names.
+
+    Returns:
+        list[str]: Output names (e.g., ["HDMI-1", "eDP-1"]), empty if none found.
+    """
+    outputs = []
     try:
         out = subprocess.check_output(["xrandr"], text=True, stderr=subprocess.DEVNULL)
         for line in out.splitlines():
             if " connected" in line:
-                return line.split()[0]
+                outputs.append(line.split()[0])
     except Exception:
         pass
-    return None
+    return outputs
 
 
 def apply_gamma(output, r, g, b):

--- a/bluelight/display/tests.py
+++ b/bluelight/display/tests.py
@@ -3,7 +3,8 @@
 import unittest
 from unittest.mock import patch
 from bluelight.display import (
-    gamma_string, build_command, get_connected_output, has_xrandr, apply_gamma
+    gamma_string, build_command, get_connected_output, get_connected_outputs,
+    has_xrandr, apply_gamma
 )
 
 
@@ -48,6 +49,59 @@ class TestGetConnectedOutput(unittest.TestCase):
     @patch("bluelight.display.subprocess.check_output", side_effect=FileNotFoundError)
     def test_xrandr_missing(self, mock_out):
         self.assertIsNone(get_connected_output())
+
+
+class TestGetConnectedOutputs(unittest.TestCase):
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_detects_multiple_displays(self, mock_out):
+        mock_out.return_value = (
+            "HDMI-1 connected 1920x1080+0+0\n"
+            "VGA-1 disconnected\n"
+            "eDP-1 connected 1366x768+1920+0\n"
+        )
+        self.assertEqual(get_connected_outputs(), ["HDMI-1", "eDP-1"])
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_single_display(self, mock_out):
+        mock_out.return_value = "HDMI-1 connected 1920x1080+0+0\n"
+        self.assertEqual(get_connected_outputs(), ["HDMI-1"])
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_three_displays(self, mock_out):
+        mock_out.return_value = (
+            "HDMI-1 connected 1920x1080+0+0\n"
+            "DP-1 connected 2560x1440+1920+0\n"
+            "VGA-1 disconnected\n"
+            "eDP-1 connected 1366x768+4480+0\n"
+        )
+        self.assertEqual(get_connected_outputs(), ["HDMI-1", "DP-1", "eDP-1"])
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_preserves_order(self, mock_out):
+        mock_out.return_value = (
+            "eDP-1 connected 1366x768+0+0\n"
+            "HDMI-1 connected 1920x1080+1366+0\n"
+        )
+        self.assertEqual(get_connected_outputs(), ["eDP-1", "HDMI-1"])
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_no_connected_displays(self, mock_out):
+        mock_out.return_value = "VGA-1 disconnected\n"
+        self.assertEqual(get_connected_outputs(), [])
+
+    @patch("bluelight.display.subprocess.check_output", side_effect=FileNotFoundError)
+    def test_xrandr_missing(self, mock_out):
+        self.assertEqual(get_connected_outputs(), [])
+
+    @patch("bluelight.display.subprocess.check_output")
+    def test_get_connected_output_returns_first(self, mock_out):
+        """get_connected_output() should return only the first display."""
+        mock_out.return_value = (
+            "HDMI-1 connected 1920x1080+0+0\n"
+            "eDP-1 connected 1366x768+1920+0\n"
+        )
+        self.assertEqual(get_connected_output(), "HDMI-1")
 
 
 class TestHasXrandr(unittest.TestCase):

--- a/bluelight/gui/app.py
+++ b/bluelight/gui/app.py
@@ -4,10 +4,14 @@ import tkinter as tk
 from bluelight.theme import (BG, CARD, BORDER, FG, FG2, ACCENT, ACC2,
                               RED, GREEN, BLUE, DARK, MONO, MONO_B, MONO_S,
                               MONO_LG, PRESETS)
-from bluelight.display import get_connected_output, apply_gamma, build_command, has_xrandr
+from bluelight.display import (get_connected_outputs, apply_gamma,
+                                build_command, has_xrandr)
 from bluelight.color import gamma_to_hex, warmth_label
 from bluelight.gui.slider import Slider
-from bluelight.config import load_config, save_config
+from bluelight.config import load_monitor_config, save_config
+
+
+ALL_MONITORS = "All Monitors"
 
 
 class App(tk.Tk):
@@ -19,20 +23,48 @@ class App(tk.Tk):
         self.configure(bg=BG)
         self.resizable(False, False)
 
-        self.output = get_connected_output()
+        self.outputs = get_connected_outputs()
         self.has_xr = has_xrandr()
 
-        # Load saved settings or use defaults
-        saved = load_config()
-        self._r = saved.get('r', 1.00)
-        self._g = saved.get('g', 0.85)
-        self._b = saved.get('b', 0.65)
+        # Per-monitor gamma values: {output_name: (r, g, b)}
+        self._monitor_gamma = {}
+        for out in self.outputs:
+            saved = load_monitor_config(out)
+            self._monitor_gamma[out] = (
+                saved.get('r', 1.00),
+                saved.get('g', 0.85),
+                saved.get('b', 0.65),
+            )
+
+        # Current selection
+        self._selected = tk.StringVar(value=self.outputs[0] if self.outputs else "")
+        r, g, b = self._current_rgb()
+        self._r, self._g, self._b = r, g, b
 
         self._build()
 
         # Auto-apply saved settings on startup
-        if saved and self.has_xr and self.output:
-            apply_gamma(self.output, self._r, self._g, self._b)
+        if self.has_xr:
+            for out in self.outputs:
+                r, g, b = self._monitor_gamma[out]
+                apply_gamma(out, r, g, b)
+
+    def _current_rgb(self):
+        """Get RGB for the currently selected monitor."""
+        sel = self._selected.get()
+        if sel == ALL_MONITORS:
+            # Show the first monitor's values as representative
+            if self.outputs:
+                return self._monitor_gamma[self.outputs[0]]
+            return (1.00, 0.85, 0.65)
+        return self._monitor_gamma.get(sel, (1.00, 0.85, 0.65))
+
+    def _target_outputs(self):
+        """Get the list of outputs affected by current selection."""
+        sel = self._selected.get()
+        if sel == ALL_MONITORS:
+            return list(self.outputs)
+        return [sel] if sel else []
 
     # ── UI Construction ───────────────────────────────────────────────────────
 
@@ -82,11 +114,38 @@ class App(tk.Tk):
         self.warm_lbl.pack(side="right")
 
     def _build_display_info(self):
-        """Build display detection info row."""
-        dtxt = f"Display: {self.output}" if self.output else "  No display detected"
-        dcol = GREEN if self.output else RED
-        tk.Label(self, text=dtxt, font=MONO_S, bg=BG, fg=dcol
-                 ).pack(anchor="w", padx=22, pady=(4, 0))
+        """Build display detection info with monitor selector."""
+        df = tk.Frame(self, bg=BG)
+        df.pack(fill="x", padx=22, pady=(4, 0))
+
+        if self.outputs:
+            dcol = GREEN
+            tk.Label(df, text=f"Displays: {len(self.outputs)} connected",
+                     font=MONO_S, bg=BG, fg=dcol).pack(side="left")
+
+            # Monitor selector dropdown
+            choices = list(self.outputs)
+            if len(choices) > 1:
+                choices.append(ALL_MONITORS)
+
+            sel_frame = tk.Frame(df, bg=BG)
+            sel_frame.pack(side="right")
+            tk.Label(sel_frame, text="Target: ", font=MONO_S,
+                     bg=BG, fg=FG2).pack(side="left")
+            self._monitor_menu = tk.OptionMenu(
+                sel_frame, self._selected, *choices,
+                command=self._monitor_changed)
+            self._monitor_menu.config(
+                font=MONO_S, bg=CARD, fg=FG, activebackground=BORDER,
+                activeforeground=FG, highlightthickness=1,
+                highlightbackground=BORDER, relief="flat", bd=0)
+            self._monitor_menu["menu"].config(
+                font=MONO_S, bg=CARD, fg=FG,
+                activebackground=ACCENT, activeforeground="#1a0900")
+            self._monitor_menu.pack(side="left")
+        else:
+            tk.Label(df, text="  No display detected",
+                     font=MONO_S, bg=BG, fg=RED).pack(side="left")
 
     def _build_presets(self):
         """Build preset buttons."""
@@ -192,12 +251,28 @@ class App(tk.Tk):
 
     # ── Callbacks ─────────────────────────────────────────────────────────────
 
+    def _monitor_changed(self, *_):
+        """Handle monitor selection change."""
+        r, g, b = self._current_rgb()
+        self._r, self._g, self._b = r, g, b
+        self._sl_r.set(r)
+        self._sl_g.set(g)
+        self._sl_b.set(b)
+        self._rl.config(text=f"{r:.2f}")
+        self._gl.config(text=f"{g:.2f}")
+        self._bl.config(text=f"{b:.2f}")
+        self._highlight_preset(-1)
+        self._refresh()
+
     def _slider_moved(self, lbl, val):
         """Handle slider movement."""
         lbl.config(text=f"{val:.2f}")
         self._r = self._sl_r.get()
         self._g = self._sl_g.get()
         self._b = self._sl_b.get()
+        # Store values for target monitors
+        for out in self._target_outputs():
+            self._monitor_gamma[out] = (self._r, self._g, self._b)
         self._highlight_preset(-1)
         self._refresh()
 
@@ -207,8 +282,12 @@ class App(tk.Tk):
         self.swatch.itemconfig(self._orb, fill=gamma_to_hex(r, g, b))
         self.vals_lbl.config(text=f"R: {r:.2f}  G: {g:.2f}  B: {b:.2f}")
         self.warm_lbl.config(text=warmth_label(b))
-        out = self.output or "<output>"
-        self._cmd_lbl.config(text=build_command(out, r, g, b))
+        targets = self._target_outputs()
+        if targets:
+            cmds = [build_command(out, r, g, b) for out in targets]
+            self._cmd_lbl.config(text="\n".join(cmds))
+        else:
+            self._cmd_lbl.config(text=build_command("<output>", r, g, b))
 
     def _preset(self, r, g, b, idx):
         """Apply a preset and highlight its button."""
@@ -219,6 +298,8 @@ class App(tk.Tk):
         self._rl.config(text=f"{r:.2f}")
         self._gl.config(text=f"{g:.2f}")
         self._bl.config(text=f"{b:.2f}")
+        for out in self._target_outputs():
+            self._monitor_gamma[out] = (r, g, b)
         self._highlight_preset(idx)
         self._refresh()
 
@@ -231,33 +312,60 @@ class App(tk.Tk):
                 btn.config(bg=CARD, fg=FG2, highlightbackground=BORDER)
 
     def _apply(self):
-        """Apply filter to connected display."""
+        """Apply filter to target displays."""
         if not self.has_xr:
             self._flash("  xrandr not found — install x11-xserver-utils", RED)
             return
-        if not self.output:
+        targets = self._target_outputs()
+        if not targets:
             self._flash("  No connected display detected", RED)
             return
-        apply_gamma(self.output, self._r, self._g, self._b)
-        self._flash("  Filter applied to display!")
+        for out in targets:
+            r, g, b = self._monitor_gamma[out]
+            apply_gamma(out, r, g, b)
+        n = len(targets)
+        label = f"{n} display{'s' if n > 1 else ''}"
+        self._flash(f"  Filter applied to {label}!")
 
     def _reset(self):
-        """Reset display to normal (no filter)."""
+        """Reset target displays to normal (no filter)."""
         self._preset(1.0, 1.0, 1.0, 0)
-        if self.has_xr and self.output:
-            apply_gamma(self.output, 1.0, 1.0, 1.0)
+        if self.has_xr:
+            for out in self._target_outputs():
+                apply_gamma(out, 1.0, 1.0, 1.0)
             self._flash("  Display reset to normal")
 
     def _copy(self):
-        """Copy generated command to clipboard."""
-        cmd = build_command(self.output or "<output>", self._r, self._g, self._b)
+        """Copy generated command(s) to clipboard."""
+        targets = self._target_outputs()
+        if targets:
+            cmds = []
+            for out in targets:
+                r, g, b = self._monitor_gamma[out]
+                cmds.append(build_command(out, r, g, b))
+            text = "\n".join(cmds)
+        else:
+            text = build_command("<output>", self._r, self._g, self._b)
         self.clipboard_clear()
-        self.clipboard_append(cmd)
+        self.clipboard_append(text)
         self._flash("  Command copied to clipboard!")
 
     def _save_permanent(self):
-        """Save current gamma settings permanently."""
-        if save_config(self._r, self._g, self._b):
+        """Save current gamma settings permanently (per-monitor)."""
+        targets = self._target_outputs()
+        if not targets:
+            if save_config(self._r, self._g, self._b):
+                self._flash("  Settings saved permanently!", GREEN)
+            else:
+                self._flash("  Failed to save settings", RED)
+            return
+
+        ok = True
+        for out in targets:
+            r, g, b = self._monitor_gamma[out]
+            if not save_config(r, g, b, output=out):
+                ok = False
+        if ok:
             self._flash("  Settings saved permanently!", GREEN)
         else:
             self._flash("  Failed to save settings", RED)

--- a/bluelight/gui/tests.py
+++ b/bluelight/gui/tests.py
@@ -53,66 +53,174 @@ class TestSliderLogic(unittest.TestCase):
 class TestAppCallbacks(unittest.TestCase):
     """Test App callback logic with mocked display."""
 
-    @patch("bluelight.gui.app.load_config", return_value={})
-    @patch("bluelight.gui.app.has_xrandr", return_value=True)
-    @patch("bluelight.gui.app.get_connected_output", return_value="HDMI-1")
-    @patch("bluelight.gui.app.apply_gamma")
-    @patch("bluelight.gui.app.tk.Tk.__init__", return_value=None)
-    def test_apply_calls_gamma(self, mock_tk, mock_apply, mock_out, mock_xr, mock_cfg):
+    def _make_app(self, outputs=None, has_xr=True, gamma=None):
+        """Create an App instance with mocked internals."""
         from bluelight.gui.app import App
         app = App.__new__(App)
-        app.output = "HDMI-1"
-        app.has_xr = True
+        app.outputs = outputs or ["HDMI-1"]
+        app.has_xr = has_xr
+        app._monitor_gamma = gamma or {"HDMI-1": (1.0, 0.85, 0.65)}
         app._r, app._g, app._b = 1.0, 0.85, 0.65
         app._status = MagicMock()
         app.after = MagicMock()
+
+        import tkinter as tk
+        app._selected = MagicMock()
+        app._selected.get.return_value = app.outputs[0] if app.outputs else ""
+        return app
+
+    @patch("bluelight.gui.app.apply_gamma")
+    def test_apply_calls_gamma(self, mock_apply):
+        app = self._make_app()
         app._apply()
         mock_apply.assert_called_once_with("HDMI-1", 1.0, 0.85, 0.65)
 
     @patch("bluelight.gui.app.apply_gamma")
+    def test_apply_all_monitors(self, mock_apply):
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        app._apply()
+        self.assertEqual(mock_apply.call_count, 2)
+
+    @patch("bluelight.gui.app.apply_gamma")
     def test_apply_blocked_without_xrandr(self, mock_apply):
-        from bluelight.gui.app import App
-        app = App.__new__(App)
-        app.output = "HDMI-1"
-        app.has_xr = False
-        app._status = MagicMock()
-        app.after = MagicMock()
+        app = self._make_app(has_xr=False)
         app._apply()
         mock_apply.assert_not_called()
 
     @patch("bluelight.gui.app.apply_gamma")
     def test_apply_blocked_without_output(self, mock_apply):
-        from bluelight.gui.app import App
-        app = App.__new__(App)
-        app.output = None
-        app.has_xr = True
-        app._status = MagicMock()
-        app.after = MagicMock()
+        app = self._make_app(outputs=[])
+        app._selected.get.return_value = ""
+        app._monitor_gamma = {}
         app._apply()
         mock_apply.assert_not_called()
 
     @patch("bluelight.gui.app.save_config", return_value=True)
-    def test_save_permanent_success(self, mock_save):
-        from bluelight.gui.app import App
-        app = App.__new__(App)
-        app._r, app._g, app._b = 1.0, 0.85, 0.65
-        app._status = MagicMock()
-        app.after = MagicMock()
+    def test_save_permanent_per_monitor(self, mock_save):
+        app = self._make_app()
         app._save_permanent()
-        mock_save.assert_called_once_with(1.0, 0.85, 0.65)
+        mock_save.assert_called_once_with(1.0, 0.85, 0.65, output="HDMI-1")
 
     @patch("bluelight.gui.app.build_command", return_value="xrandr --output HDMI-1 --gamma 1.00:0.85:0.65")
     def test_copy_to_clipboard(self, mock_cmd):
-        from bluelight.gui.app import App
-        app = App.__new__(App)
-        app.output = "HDMI-1"
-        app._r, app._g, app._b = 1.0, 0.85, 0.65
-        app._status = MagicMock()
-        app.after = MagicMock()
+        app = self._make_app()
         app.clipboard_clear = MagicMock()
         app.clipboard_append = MagicMock()
         app._copy()
-        app.clipboard_append.assert_called_once_with("xrandr --output HDMI-1 --gamma 1.00:0.85:0.65")
+        app.clipboard_append.assert_called_once()
+
+    @patch("bluelight.gui.app.apply_gamma")
+    def test_apply_single_monitor_from_multi(self, mock_apply):
+        """Selecting one monitor only applies to that monitor."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "eDP-1"
+        app._apply()
+        mock_apply.assert_called_once_with("eDP-1", 1.0, 0.75, 0.50)
+
+    @patch("bluelight.gui.app.apply_gamma")
+    def test_apply_all_monitors_uses_per_monitor_gamma(self, mock_apply):
+        """All Monitors applies each monitor's own stored gamma."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        app._apply()
+        calls = mock_apply.call_args_list
+        self.assertEqual(calls[0], (("HDMI-1", 1.0, 0.85, 0.65),))
+        self.assertEqual(calls[1], (("eDP-1", 1.0, 0.75, 0.50),))
+
+    @patch("bluelight.gui.app.apply_gamma")
+    def test_reset_resets_all_targeted(self, mock_apply):
+        """Reset applies 1.0/1.0/1.0 to all targeted monitors."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        app._pbtns = [MagicMock() for _ in range(5)]
+        app._sl_r = MagicMock(get=MagicMock(return_value=1.0))
+        app._sl_g = MagicMock(get=MagicMock(return_value=1.0))
+        app._sl_b = MagicMock(get=MagicMock(return_value=1.0))
+        app._rl = MagicMock()
+        app._gl = MagicMock()
+        app._bl = MagicMock()
+        app.swatch = MagicMock()
+        app._orb = "orb"
+        app.vals_lbl = MagicMock()
+        app.warm_lbl = MagicMock()
+        app._cmd_lbl = MagicMock()
+        app._reset()
+        # Should have called apply_gamma with 1.0 for both monitors
+        reset_calls = [c for c in mock_apply.call_args_list
+                       if c == (("HDMI-1", 1.0, 1.0, 1.0),)
+                       or c == (("eDP-1", 1.0, 1.0, 1.0),)]
+        self.assertEqual(len(reset_calls), 2)
+
+    @patch("bluelight.gui.app.save_config", return_value=True)
+    def test_save_permanent_all_monitors(self, mock_save):
+        """Save permanently saves each monitor's gamma individually."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        app._save_permanent()
+        calls = mock_save.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], ((1.0, 0.85, 0.65,), {"output": "HDMI-1"}))
+        self.assertEqual(calls[1], ((1.0, 0.75, 0.50,), {"output": "eDP-1"}))
+
+    def test_target_outputs_single(self):
+        """_target_outputs returns single monitor when one is selected."""
+        app = self._make_app(outputs=["HDMI-1", "eDP-1"])
+        app._selected.get.return_value = "HDMI-1"
+        self.assertEqual(app._target_outputs(), ["HDMI-1"])
+
+    def test_target_outputs_all(self):
+        """_target_outputs returns all monitors when All Monitors is selected."""
+        app = self._make_app(outputs=["HDMI-1", "eDP-1"])
+        app._selected.get.return_value = "All Monitors"
+        self.assertEqual(app._target_outputs(), ["HDMI-1", "eDP-1"])
+
+    def test_target_outputs_empty(self):
+        """_target_outputs returns empty list when no selection."""
+        app = self._make_app(outputs=[])
+        app._selected.get.return_value = ""
+        self.assertEqual(app._target_outputs(), [])
+
+    def test_current_rgb_specific_monitor(self):
+        """_current_rgb returns the selected monitor's gamma."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "eDP-1"
+        self.assertEqual(app._current_rgb(), (1.0, 0.75, 0.50))
+
+    def test_current_rgb_all_monitors(self):
+        """_current_rgb returns first monitor's gamma for All Monitors."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        self.assertEqual(app._current_rgb(), (1.0, 0.85, 0.65))
+
+    @patch("bluelight.gui.app.build_command", side_effect=lambda out, r, g, b: f"xrandr --output {out} --gamma {r:.2f}:{g:.2f}:{b:.2f}")
+    def test_copy_all_monitors_multiple_commands(self, mock_cmd):
+        """Copy with All Monitors produces one command per monitor."""
+        app = self._make_app(
+            outputs=["HDMI-1", "eDP-1"],
+            gamma={"HDMI-1": (1.0, 0.85, 0.65), "eDP-1": (1.0, 0.75, 0.50)})
+        app._selected.get.return_value = "All Monitors"
+        app.clipboard_clear = MagicMock()
+        app.clipboard_append = MagicMock()
+        app._copy()
+        text = app.clipboard_append.call_args[0][0]
+        self.assertIn("HDMI-1", text)
+        self.assertIn("eDP-1", text)
+        self.assertEqual(text.count("xrandr"), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Detect all connected displays via xrandr and allow independent gamma adjustment per monitor. Adds a target dropdown in the GUI, per-monitor config persistence, and "All Monitors" bulk control. Backward compatible with legacy single-monitor config format.